### PR TITLE
Fix bug in addition where 60 minutes didn't overflow to 1 degree

### DIFF
--- a/DegreeCalculator/Model/DegreeCore.swift
+++ b/DegreeCalculator/Model/DegreeCore.swift
@@ -93,8 +93,7 @@ struct Expr: CustomStringConvertible, Hashable, Codable {
                 // this extremely literal version is an easy to
                 // understand/read reflection of how a person does
                 // this math.
-                
-                while minutes > 60.0 {
+                while minutes >= 60.0 {
                     degrees += 1
                     minutes -= 60.0
                 }

--- a/DegreeCalculatorTests/DegreeCoreTests.swift
+++ b/DegreeCalculatorTests/DegreeCoreTests.swift
@@ -58,14 +58,22 @@ final class DegreeCoreTests: XCTestCase {
         
     }
 
-    func testAddTwoValues() throws {
+    func testAddTwoValues_1() throws {
         let lhs = Expr(Value(degrees: 1, minutes: 2.3))
         let rhs = Expr(Value(degrees: 4, minutes: 5.6))
         let expected = Value(degrees: 5, minutes: 7.9)
         let expr = Expr(op: Operator.Add, left: lhs, right: rhs)
         XCTAssertEqual(expr.value, expected)
     }
-    
+
+    func testAddTwoValues_minutes_overflow() throws {
+        let lhs = Expr(Value(degrees: 4, minutes: 30.0))
+        let rhs = Expr(Value(degrees: 4, minutes: 30.0))
+        let expected = Value(degrees: 9, minutes: 0.0)
+        let expr = Expr(op: Operator.Add, left: lhs, right: rhs)
+        XCTAssertEqual(expr.value, expected)
+    }
+
     func testSubtractTwoValues() throws {
         let lhs = Expr(Value(degrees: 4, minutes: 5.6))
         let rhs = Expr(Value(degrees: 1, minutes: 2.3))


### PR DESCRIPTION
There was just a `=` missing from `>= 60`.

Eg. adding 1°30.0' + 1°30.0' gave 2°60.0' instead of 3°00.0'.