### PR TITLE
Add divide and -360° functionality.

### DIFF
--- a/DegreeCalculator/Model/DegreeCore.swift
+++ b/DegreeCalculator/Model/DegreeCore.swift
@@ -180,6 +180,19 @@ struct Expr: CustomStringConvertible, Hashable, Codable {
     }
     
     /**
+     Find rightmost open node.
+     */
+    public func rightMost(): Expr
+        if nodes.count > 0 {
+            nodes[0].inOrder(visit: visit)
+        }
+        visit(self)
+        if nodes.count > 1 {
+            nodes[1].inOrder(visit: visit)
+        }
+    }
+    
+    /**
      value recursively computes the expression value.
      If the expression is fully formed (has operator, left and right), this function
      computes the value by applying the operator to the result of calling

--- a/DegreeCalculator/Model/DegreeCore.swift
+++ b/DegreeCalculator/Model/DegreeCore.swift
@@ -217,7 +217,7 @@ struct Expr: CustomStringConvertible, Hashable, Codable {
                 result.append(")")
             }
         }
-        return result.joined(separator: " ")
+        return result.joined(separator: "")
     }
     
     public func inOrder(visit: (Expr) -> Void) {

--- a/DegreeCalculator/Model/DegreeCore.swift
+++ b/DegreeCalculator/Model/DegreeCore.swift
@@ -89,6 +89,10 @@ struct Expr: CustomStringConvertible, Hashable, Codable {
                 return nil
             }
 
+            // This recursively evaluates the expression by
+            // accessing nodes[0] and [1] (left and right).
+            // If any expression returns nil, the expression can't
+            // be evaluated, eg. missing left/right
             if let lv = nodes[0].value, let rv = nodes[1].value {
                 var degrees: Int = 0
                 var minutes: Decimal = 0.0
@@ -125,6 +129,9 @@ struct Expr: CustomStringConvertible, Hashable, Codable {
                         
                         degrees = rounded.intValue / 60
                         minutes = rounded.decimalValue - Decimal(degrees * 60)
+                    } else {
+                        // left of right node is nil,
+                        return nil
                     }
                 }
                 
@@ -152,7 +159,8 @@ struct Expr: CustomStringConvertible, Hashable, Codable {
                 }
                 return Value(degrees: degrees, minutes: minutes)
             } else {
-                return nodes[0].value
+                // Neither left not right value means nil
+                return nil 
             }
         }
     }

--- a/DegreeCalculator/Model/ModelData.swift
+++ b/DegreeCalculator/Model/ModelData.swift
@@ -306,11 +306,10 @@ final class ModelData: ObservableObject {
                 entries.removeLast()
                 entries.append(root)
             } else if root.op != nil && root.nodes.count == 1 {
-                Fail compile here
-                TODO I bet this won't work with things like "3 + 3 + 3 / 3 / 3" being entered
                 // Root has a left side and an operator.
                 // Determine operator precedence to determine which side to add it
                 if op == Operator.Divide && (root.op == Operator.Add || root.op == Operator.Subtract) {
+                    // Inserting a higher precedence, so move current node to the left.
                     let newRoot = Expr(op: op, left: node, right: nil)
                     root.nodes.append(newRoot)
                     entries.removeLast()
@@ -371,11 +370,11 @@ final class ModelData: ObservableObject {
         }
         
         if var root = entries.last {
-            Fail compile here
             TODO: root.nodes.count == 1 assumes a right balanced tree
             instead of assuming that and inserting the current Expression
             there, we have to support a tree like (+ 1 2) + (/ 3 <empty>)
-            that means walk the tree and find where to insert the node
+            that means walk the tree and find the rightmost open node.
+            
             if root.op != nil && root.nodes.count == 1 {
                 let node: Expr
                 if root.op == Operator.Divide {

--- a/DegreeCalculator/Model/ModelData.swift
+++ b/DegreeCalculator/Model/ModelData.swift
@@ -255,11 +255,22 @@ final class ModelData: ObservableObject {
                 entries.removeLast()
                 entries.append(root)
             } else if root.op != nil && root.nodes.count == 1 {
-                // Root has a left side & operator, add right side value and new operator
-                root.nodes.append(node)
-                let newRoot = Expr(op: op, left: root, right: nil)
-                entries.removeLast()
-                entries.append(newRoot)
+                Fail compile here
+                TODO I bet this won't work with things like "3 + 3 + 3 / 3 / 3" being entered
+                // Root has a left side and an operator.
+                // Determine operator precedence to determine which side to add it
+                if op == Operator.Divide && (root.op == Operator.Add || root.op == Operator.Subtract) {
+                    let newRoot = Expr(op: op, left: node, right: nil)
+                    root.nodes.append(newRoot)
+                    entries.removeLast()
+                    entries.append(root)
+                } else {
+                    // Add right side value and new operator
+                    root.nodes.append(node)
+                    let newRoot = Expr(op: op, left: root, right: nil)
+                    entries.removeLast()
+                    entries.append(newRoot)
+                }
             }
         } else {
             NSLog("entries has no root?")
@@ -309,6 +320,11 @@ final class ModelData: ObservableObject {
         }
         
         if var root = entries.last {
+            Fail compile here
+            TODO: root.nodes.count == 1 assumes a right balanced tree
+            instead of assuming that and inserting the current Expression
+            there, we have to support a tree like (+ 1 2) + (/ 3 <empty>)
+            that means walk the tree and find where to insert the node
             if root.op != nil && root.nodes.count == 1 {
                 let node: Expr
                 if root.op == Operator.Divide {

--- a/DegreeCalculator/Views/Calculator.swift
+++ b/DegreeCalculator/Views/Calculator.swift
@@ -169,7 +169,7 @@ struct Calculator: View {
                     CalculatorButton(label: "1", function: CalculatorFunction.ENTRY)
                     CalculatorButton(label: "2", function: CalculatorFunction.ENTRY)
                     CalculatorButton(label: "3", function: CalculatorFunction.ENTRY)
-                    CalculatorButton(label: "/", function: CalculatorFunction.DIV)
+                    CalculatorButton(label: "AVG", function: CalculatorFunction.DIV)
                 }
                 GridRow {
                     CalculatorButton(label: "0", function: CalculatorFunction.ENTRY)

--- a/DegreeCalculator/Views/Calculator.swift
+++ b/DegreeCalculator/Views/Calculator.swift
@@ -21,6 +21,7 @@ extension String {
 struct Calculator: View {
     @EnvironmentObject var modelData: ModelData
     @State var padTop = 0.0
+    @State var padRight = 0.0
     
     struct Line: Hashable {
         var id = 0
@@ -132,30 +133,52 @@ struct Calculator: View {
                     CalculatorButton(label: "AC", function: CalculatorFunction.ALL_CLEAR)
                     CalculatorButton(label: "C", function: CalculatorFunction.CLEAR)
                     CalculatorButton(label: "DEL", function: CalculatorFunction.DELETE)
+#if false
+                        .background(
+                            GeometryReader { geo in
+                                /* See https://stackoverflow.com/a/68291983/21866895
+                                 for how the Geometry reader here is done.
+                                 It reads the Button's height and then padds by that (negative) to move up.
+                                 The extra -1.0 seems to be needed.
+                                 */
+                                Color.clear.onAppear {
+                                    padTop = -geo.size.height-1.0
+                                }
+                            }
+                        )
+#endif
+                        .padding(.trailing, padTop)
                     CalculatorButton(label: "ANS", function: CalculatorFunction.ANS)
-               }
+                        .disabled(modelData.disableDegreesAndMinutes)
+                }
                 GridRow {
                     CalculatorButton(label: "7", function: CalculatorFunction.ENTRY)
                     CalculatorButton(label: "8", function: CalculatorFunction.ENTRY)
                     CalculatorButton(label: "9", function: CalculatorFunction.ENTRY)
                     CalculatorButton(label: "+", function: CalculatorFunction.ADD)
-               }
+                }
                 GridRow {
                     CalculatorButton(label: "4", function: CalculatorFunction.ENTRY)
                     CalculatorButton(label: "5", function: CalculatorFunction.ENTRY)
                     CalculatorButton(label: "6", function: CalculatorFunction.ENTRY)
-                    CalculatorButton(label: "-", function: CalculatorFunction.SUBTRACT)
+                    CalculatorButton(label: "-",
+                                     function: CalculatorFunction.SUBTRACT,
+                                     tripleTapFunction: CalculatorFunction.M360)
                 }
                 GridRow {
                     CalculatorButton(label: "1", function: CalculatorFunction.ENTRY)
                     CalculatorButton(label: "2", function: CalculatorFunction.ENTRY)
                     CalculatorButton(label: "3", function: CalculatorFunction.ENTRY)
+                    CalculatorButton(label: "/", function: CalculatorFunction.DIV)
                 }
                 GridRow {
                     CalculatorButton(label: "0", function: CalculatorFunction.ENTRY)
                     CalculatorButton(label: "°", function: CalculatorFunction.ENTRY)
+                        .disabled(modelData.disableDegreesAndMinutes)
                     CalculatorButton(label: "'", function: CalculatorFunction.ENTRY)
+                        .disabled(modelData.disableDegreesAndMinutes)
                     CalculatorButton(label: "=", function: CalculatorFunction.EQUAL)
+#if false
                         .background(
                             GeometryReader { geo in
                                 /* See https://stackoverflow.com/a/68291983/21866895
@@ -169,6 +192,7 @@ struct Calculator: View {
                             }
                         )
                         .padding(.top, padTop)
+#endif
                 }
             }
             .padding([.bottom], 20)
@@ -181,7 +205,7 @@ struct Calculator: View {
 
 struct Calculator_Previews: PreviewProvider {
     static var previews: some View {
-        ForEach(["iPhone 11 Pro", "iPhone 13 Pro", "iPhone 14 Pro", "iPhone SE (3rd generation)", "iPad (10th generation)"], id: \.self) { deviceName in
+        ForEach(["iPhone 16 Pro", "iPhone 11 Pro", "iPhone 13 Pro", "iPhone 14 Pro", "iPhone SE (3rd generation)", "iPad (10th generation)"], id: \.self) { deviceName in
             Calculator()
                 .environmentObject(ModelData())
                 .previewDevice(PreviewDevice(rawValue: deviceName))

--- a/DegreeCalculator/Views/CalculatorButton.swift
+++ b/DegreeCalculator/Views/CalculatorButton.swift
@@ -7,20 +7,62 @@
 
 import SwiftUI
 
+// AI prompt, "Write a swiftui function to mute a variable of type Color"
+extension UIColor {
+    func withMutedAdjustment(_ factor: Double) -> UIColor {
+        var hue: CGFloat = 0
+        var saturation: CGFloat = 0
+        var brightness: CGFloat = 0
+        var alpha: CGFloat = 0
+        
+        // Get the HSB components of the color
+        if getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha) {
+            // Handle grays (low saturation)
+            if saturation < 0.05 {
+                let newBrightness = max(0.0, min(brightness * CGFloat(factor), 1.0))
+                return UIColor(hue: hue, saturation: saturation, brightness: newBrightness, alpha: alpha)
+            } else {
+                // For non-grays, adjust saturation
+                let newSaturation = max(0.0, min(saturation * CGFloat(factor), 1.0))
+                return UIColor(hue: hue, saturation: newSaturation, brightness: brightness, alpha: alpha)
+            }
+        }
+        
+        return self // Return self if hue extraction fails
+    }
+}
+
+
 struct CalculatorButton: View {
     @EnvironmentObject var modelData: ModelData
+    @Environment(\.isEnabled) var isEnabled
+
     var label: String
     var function: CalculatorFunction = CalculatorFunction.ENTRY
+    var tripleTapFunction: CalculatorFunction?
 
-    var fg: Color {
+    // This functions returns the default color of a button by it's function,
+    // then `fg` mutes it if it's disbled.
+    var enabled_fg: Color {
         switch function {
-        case .ADD, .SUBTRACT:
+        case .ADD, .SUBTRACT, .DIV, .M360:
             return Color.black
         default:
             return Color.white
         }
     }
-    var bg: Color {
+    
+    var fg: Color {
+        let result: Color = enabled_fg
+        if (!isEnabled) {
+            return Color(UIColor(result).withMutedAdjustment(0.4))
+        }
+        return result
+    }
+    
+    // This functions returns the default color of a button by it's function,
+    // then `bg` mutes it if it's disbled.
+    var enabled_bg: Color {
         switch function {
         case .ALL_CLEAR:
             return Color.red
@@ -30,11 +72,20 @@ struct CalculatorButton: View {
             return Color.brown
         case .EQUAL:
             return Color.green
-        case .ADD, .SUBTRACT:
+        case .ADD, .SUBTRACT, .DIV, .M360:
             return Color.yellow
         default:
             return Color.gray
         }
+    }
+    
+    var bg: Color {
+        let result: Color = enabled_bg
+        if (!isEnabled) {
+            return Color(UIColor(result).withMutedAdjustment(0.4))
+        }
+
+        return result
     }
     var body: some View {
         Button(action: {
@@ -44,6 +95,11 @@ struct CalculatorButton: View {
                 .font(.system(.largeTitle, design: .monospaced))
         }
         .buttonStyle(CalculatorButtonStyle(foregroundColor: fg, backgroundColor: bg))
+        .onTapGesture(count: 3) {
+            if let fn = tripleTapFunction {
+                modelData.callFunction(fn, label: label)
+            }
+        }
     }
 }
 

--- a/DegreeCalculatorTests/DegreeCoreTests.swift
+++ b/DegreeCalculatorTests/DegreeCoreTests.swift
@@ -82,11 +82,42 @@ final class DegreeCoreTests: XCTestCase {
         XCTAssertEqual(expr.value, expected)
     }
     
+    func testDivideValues_base_case() throws {
+        let lhs = Expr(Value(degrees: 1023, minutes: 6.3))
+        let rhs = Expr(Value(degrees: 3, minutes:0.0))
+        let expected = Value(degrees: 341, minutes: 2.1)
+        let expr = Expr(op: Operator.Divide, left: lhs, right: rhs)
+        XCTAssertEqual(expr.value, expected)
+    }
+
+    func testDivideValues_ignores_minutes() throws {
+        let lhs = Expr(Value(degrees: 1023, minutes: 6.3))
+        let rhs = Expr(Value(degrees: 3, minutes:99.9))
+        let expected = Value(degrees: 341, minutes: 2.1)
+        let expr = Expr(op: Operator.Divide, left: lhs, right: rhs)
+        XCTAssertEqual(expr.value, expected)
+    }
+
+    
+    func testDivideValues_degrees_divvy_into_minutes() throws {
+        let lhs = Expr(Value(degrees: 9, minutes: 0.0))
+        let rhs = Expr(Value(degrees: 2, minutes: 0.0))
+        let expected = Value(degrees: 4, minutes: 30.0)
+        let expr = Expr(op: Operator.Divide, left: lhs, right: rhs)
+        XCTAssertEqual(expr.value, expected)
+    }
+
     func testDegreesAndMinutesOverflow() throws {
         let lhs = Expr(Value(degrees: 354, minutes: 54.5))
         let rhs = Expr(Value(degrees: 6, minutes: 6.6))
-        let expected = Value(degrees: 1, minutes: 1.1)
         let expr = Expr(op: Operator.Add, left: lhs, right: rhs)
+        /*
+         Search for NOTE: disable auto overflow subtractions as we add -360 button instead
+
+        let expected = Value(degrees: 1, minutes: 1.1)
+        XCTAssertEqual(expr.value, expected)
+        */
+        let expected = Value(degrees: 361, minutes: 1.1)
         XCTAssertEqual(expr.value, expected)
     }
     

--- a/DegreeCalculatorTests/DegreeCoreTests.swift
+++ b/DegreeCalculatorTests/DegreeCoreTests.swift
@@ -84,24 +84,15 @@ final class DegreeCoreTests: XCTestCase {
     
     func testDivideValues_base_case() throws {
         let lhs = Expr(Value(degrees: 1023, minutes: 6.3))
-        let rhs = Expr(Value(degrees: 3, minutes:0.0))
+        let rhs = Expr(Value(integer: 3))
         let expected = Value(degrees: 341, minutes: 2.1)
         let expr = Expr(op: Operator.Divide, left: lhs, right: rhs)
         XCTAssertEqual(expr.value, expected)
     }
-
-    func testDivideValues_ignores_minutes() throws {
-        let lhs = Expr(Value(degrees: 1023, minutes: 6.3))
-        let rhs = Expr(Value(degrees: 3, minutes:99.9))
-        let expected = Value(degrees: 341, minutes: 2.1)
-        let expr = Expr(op: Operator.Divide, left: lhs, right: rhs)
-        XCTAssertEqual(expr.value, expected)
-    }
-
     
     func testDivideValues_degrees_divvy_into_minutes() throws {
         let lhs = Expr(Value(degrees: 9, minutes: 0.0))
-        let rhs = Expr(Value(degrees: 2, minutes: 0.0))
+        let rhs = Expr(Value(integer: 2))
         let expected = Value(degrees: 4, minutes: 30.0)
         let expr = Expr(op: Operator.Divide, left: lhs, right: rhs)
         XCTAssertEqual(expr.value, expected)

--- a/DegreeCalculatorTests/ModelDataTests.swift
+++ b/DegreeCalculatorTests/ModelDataTests.swift
@@ -290,9 +290,11 @@ final class ModelDataTests: XCTestCase {
                                                                right: Expr(Value(degrees: 2, minutes: 0.0))
                                                               ),
                                                     right: Expr(Value(degrees: 3, minutes: 0.0))))])
+        XCTAssertEqual(md.entries.last?.description, "(((1°00'0+2°00'0)+3°00'0)+<empty>)")
         XCTAssertEqual(md.entered, "")
     }
     
+    /*
     func testDivide_wrong_add_add_divide_left_sided_tree() {
         md.entered = "1"
         md.callFunction(CalculatorFunction.ADD, label: "")
@@ -310,13 +312,14 @@ final class ModelDataTests: XCTestCase {
         ])
         XCTAssertEqual(md.entered, "")
     }
+    */
     
     func testDivide_right_add_add_divide() {
-        md.entered = "9"
+        md.entered = "1"
         md.callFunction(CalculatorFunction.ADD, label: "")
-        md.entered = "9"
+        md.entered = "2"
         md.callFunction(CalculatorFunction.ADD, label: "")
-        md.entered = "9"
+        md.entered = "3"
         md.callFunction(CalculatorFunction.DIV, label: "")
         XCTAssertEqual(md.entries, [Expr(op: Operator.Add,
                                          left: Expr(op: Operator.Add,
@@ -327,6 +330,7 @@ final class ModelDataTests: XCTestCase {
                                                      left: Expr(Value(degrees: 3, minutes: 0.0))
                                                     ))
         ])
+        XCTAssertEqual(md.entries.last?.description, "((1°00'0+2°00'0)+(3°00'0/<empty>))")
         XCTAssertEqual(md.entered, "")
     }
 }

--- a/DegreeCalculatorTests/ModelDataTests.swift
+++ b/DegreeCalculatorTests/ModelDataTests.swift
@@ -235,7 +235,31 @@ final class ModelDataTests: XCTestCase {
                            left: Expr(Value(degrees: 1, minutes: 2.3)),
                            right: Expr(Value(degrees: 4, minutes: 5.6))),
                       Expr()]
+        md.callFunction(CalculatorFunction.EQUAL, label: "")
         md.callFunction(CalculatorFunction.ANS, label: "")
         XCTAssertEqual(md.entered, "5°07'9")
+    }
+    
+    func testMinus360() {
+        md.entered = "361°02'3"
+        // Check that Minus 360 adds a subtract operation for 360
+        md.callFunction(CalculatorFunction.M360, label: "")
+        XCTAssertEqual(md.entries, [Expr(op: Operator.Subtract,
+                                             left: Expr(Value(degrees: 361, minutes: 2.3)),
+                                             right: Expr(Value(degrees: 360, minutes: 0.0))),
+                                    Expr()])
+        XCTAssertEqual(md.entered, "")
+    }
+
+    func testMinus360_resets_operator() {
+        md.entered = "361°02'3"
+        md.callFunction(CalculatorFunction.ADD, label: "")
+        // Check that Minus 360 adds a subtract operation for 360
+        md.callFunction(CalculatorFunction.M360, label: "")
+        XCTAssertEqual(md.entries, [Expr(op: Operator.Subtract,
+                                             left: Expr(Value(degrees: 361, minutes: 2.3)),
+                                             right: Expr(Value(degrees: 360, minutes: 0.0))),
+                                    Expr()])
+        XCTAssertEqual(md.entered, "")
     }
 }

--- a/DegreeCalculatorTests/ModelDataTests.swift
+++ b/DegreeCalculatorTests/ModelDataTests.swift
@@ -11,15 +11,15 @@ import XCTest
 
 final class ModelDataTests: XCTestCase {
     var md: ModelData! = nil
-
+    
     override func setUp() {
         md = ModelData()
     }
-
+    
     override func tearDown() {
         md = nil
     }
-
+    
     // Test behaviour of clear, specifically that entered is reset and entries is unchanged.
     func testClear() throws {
         md.callFunction(CalculatorFunction.CLEAR, label: "")
@@ -33,7 +33,7 @@ final class ModelDataTests: XCTestCase {
         XCTAssertEqual(md.entries, entries)
         XCTAssertEqual(md.entered, "")
     }
-
+    
     // Test behaviour of all-clear, specifically that entered and entries is reset
     func testAllClear() throws {
         md.callFunction(CalculatorFunction.ALL_CLEAR, label: "")
@@ -95,11 +95,11 @@ final class ModelDataTests: XCTestCase {
         XCTAssertEqual(md.entries, [Expr()])
         XCTAssertEqual(md.entered, "0°0'1")
     }
-
+    
     // Test shortcut building by pressing ' without numbers or degrees
     func testEntryShortcutMinutes() throws {
         md.entered = ""
-
+        
         md.callFunction(CalculatorFunction.ENTRY, label: "'")
         XCTAssertEqual(md.entries, [Expr()])
         XCTAssertEqual(md.entered, "0°0'")
@@ -119,16 +119,16 @@ final class ModelDataTests: XCTestCase {
         md.callFunction(CalculatorFunction.ENTRY, label: "°")
         XCTAssertEqual(md.entries, [Expr()])
         XCTAssertEqual(md.entered, "1°")
-
+        
         // Immediate repeated degree
         md.callFunction(CalculatorFunction.ENTRY, label: "°")
         XCTAssertEqual(md.entries, [Expr()])
         XCTAssertEqual(md.entered, "1°")
-
+        
         md.callFunction(CalculatorFunction.ENTRY, label: "2")
         XCTAssertEqual(md.entries, [Expr()])
         XCTAssertEqual(md.entered, "1°2")
-
+        
         // Repeated degree later in string that immediate repeat
         md.callFunction(CalculatorFunction.ENTRY, label: "°")
         XCTAssertEqual(md.entries, [Expr()])
@@ -137,12 +137,12 @@ final class ModelDataTests: XCTestCase {
         md.callFunction(CalculatorFunction.ENTRY, label: "'")
         XCTAssertEqual(md.entries, [Expr()])
         XCTAssertEqual(md.entered, "1°2'")
-
+        
         // Immediate repeated minute
         md.callFunction(CalculatorFunction.ENTRY, label: "'")
         XCTAssertEqual(md.entries, [Expr()])
         XCTAssertEqual(md.entered, "1°2'")
-
+        
         md.callFunction(CalculatorFunction.ENTRY, label: "3")
         XCTAssertEqual(md.entries, [Expr()])
         XCTAssertEqual(md.entered, "1°2'3")
@@ -208,28 +208,28 @@ final class ModelDataTests: XCTestCase {
         md.entered = "0"
         XCTAssertEqual(md.prepExpr(toDMS: true), Expr(Value(degrees: 0, minutes: 0.0)))
         XCTAssertEqual(md.entered, "0°0'0")
-
+        
         md.entered = "0"
         XCTAssertEqual(md.prepExpr(toDMS: false), Expr(Value(integer: 0)))
         XCTAssertEqual(md.entered, "0")
-
+        
         md.entered = "1°"
         XCTAssertEqual(md.prepExpr(toDMS: true), Expr(Value(degrees: 1, minutes: 0.0)))
         XCTAssertEqual(md.entered, "1°0'0")
-
+        
         // Parseing 1d as not-DMS yields 0
         md.entered = "1°"
         XCTAssertEqual(md.prepExpr(toDMS: false), Expr(Value(integer: 0)))
         XCTAssertEqual(md.entered, "1°")
-
+        
         md.entered = "1"
         XCTAssertEqual(md.prepExpr(toDMS: false), Expr(Value(integer: 1)))
         XCTAssertEqual(md.entered, "1")
-
+        
         md.entered = "1°2"
         XCTAssertEqual(md.prepExpr(toDMS: true), Expr(Value(degrees: 1, minutes: 2.0)))
         XCTAssertEqual(md.entered, "1°2'0")
-
+        
         md.entered = "1°2'"
         XCTAssertEqual(md.prepExpr(toDMS: true), Expr(Value(degrees: 1, minutes: 2.0)))
         XCTAssertEqual(md.entered, "1°2'0")
@@ -258,20 +258,20 @@ final class ModelDataTests: XCTestCase {
         // Check that Minus 360 adds a subtract operation for 360
         md.callFunction(CalculatorFunction.M360, label: "")
         XCTAssertEqual(md.entries, [Expr(op: Operator.Subtract,
-                                             left: Expr(Value(degrees: 361, minutes: 2.3)),
-                                             right: Expr(Value(degrees: 360, minutes: 0.0))),
+                                         left: Expr(Value(degrees: 361, minutes: 2.3)),
+                                         right: Expr(Value(degrees: 360, minutes: 0.0))),
                                     Expr()])
         XCTAssertEqual(md.entered, "")
     }
-
+    
     func testMinus360_resets_operator() {
         md.entered = "361°02'3"
         md.callFunction(CalculatorFunction.ADD, label: "")
         // Check that Minus 360 adds a subtract operation for 360
         md.callFunction(CalculatorFunction.M360, label: "")
         XCTAssertEqual(md.entries, [Expr(op: Operator.Subtract,
-                                             left: Expr(Value(degrees: 361, minutes: 2.3)),
-                                             right: Expr(Value(degrees: 360, minutes: 0.0))),
+                                         left: Expr(Value(degrees: 361, minutes: 2.3)),
+                                         right: Expr(Value(degrees: 360, minutes: 0.0))),
                                     Expr()])
         XCTAssertEqual(md.entered, "")
     }
@@ -295,24 +295,24 @@ final class ModelDataTests: XCTestCase {
     }
     
     /*
-    func testDivide_wrong_add_add_divide_left_sided_tree() {
-        md.entered = "1"
-        md.callFunction(CalculatorFunction.ADD, label: "")
-        md.entered = "2"
-        md.callFunction(CalculatorFunction.ADD, label: "")
-        md.entered = "3"
-        md.callFunction(CalculatorFunction.DIV, label: "")
-        XCTAssertEqual(md.entries, [Expr(op: Operator.Divide,
-                                         left: Expr(op: Operator.Add,
-                                                    left: Expr(op: Operator.Add,
-                                                               left: Expr(Value(degrees: 1, minutes: 0.0)),
-                                                               right: Expr(Value(degrees: 2, minutes: 0.0))
-                                                              ),
-                                                    right: Expr(Value(degrees: 3, minutes: 0))))
-        ])
-        XCTAssertEqual(md.entered, "")
-    }
-    */
+     func testDivide_wrong_add_add_divide_left_sided_tree() {
+     md.entered = "1"
+     md.callFunction(CalculatorFunction.ADD, label: "")
+     md.entered = "2"
+     md.callFunction(CalculatorFunction.ADD, label: "")
+     md.entered = "3"
+     md.callFunction(CalculatorFunction.DIV, label: "")
+     XCTAssertEqual(md.entries, [Expr(op: Operator.Divide,
+     left: Expr(op: Operator.Add,
+     left: Expr(op: Operator.Add,
+     left: Expr(Value(degrees: 1, minutes: 0.0)),
+     right: Expr(Value(degrees: 2, minutes: 0.0))
+     ),
+     right: Expr(Value(degrees: 3, minutes: 0))))
+     ])
+     XCTAssertEqual(md.entered, "")
+     }
+     */
     
     func testDivide_right_add_add_divide() {
         md.entered = "1"
@@ -333,4 +333,30 @@ final class ModelDataTests: XCTestCase {
         XCTAssertEqual(md.entries.last?.description, "((1°00'0+2°00'0)+(3°00'0/<empty>))")
         XCTAssertEqual(md.entered, "")
     }
+    func testDivide_right_add_add_divide_divide() {
+        md.entered = "6"
+        md.callFunction(CalculatorFunction.ADD, label: "")
+        md.entered = "5"
+        md.callFunction(CalculatorFunction.ADD, label: "")
+        md.entered = "4"
+        md.callFunction(CalculatorFunction.DIV, label: "")
+        md.entered = "3"
+        md.callFunction(CalculatorFunction.DIV, label: "")
+        md.entered = "2"
+        XCTAssertEqual(md.entries, [Expr(op: Operator.Add,
+                                         left: Expr(op: Operator.Add,
+                                                    left: Expr(Value(degrees: 6, minutes: 0.0)),
+                                                    right: Expr(Value(degrees: 5, minutes: 0.0))
+                                                   ),
+                                         right: Expr(op: Operator.Divide,
+                                                     left: Expr(op: Operator.Divide,
+                                                                left: Expr(Value(degrees: 4, minutes: 0.0),
+                                                                right: Expr(Value(degrees: 3, minutes: 0.0))
+                                                     right: Expr(Value(degrees: 2, minutes: 0.0))
+                                                    ))
+        ])
+        XCTAssertEqual(md.entries.last?.description, "((6°00'0+5°00'0)+((4°00'0/3)/2))")
+        XCTAssertEqual(md.entered, "")
+    }
+    
 }


### PR DESCRIPTION
* Divide disables °, ' and ANS buttons
* Only uses the degrees part to divide with
* Takes over the double height of = button
* -360° is kind an easter egg, triple tap - (also because I can't fit an 21st button)
* Tests for both
* -360 means removing the >=360 overflow

So now I can add 340°+341°+342°, press / 3 and I
get 1023°/3 = 341°.

The missing part is that 3 shows as "3°00'0" in the display. I need to make values handle degrees/minutes and ints differently.